### PR TITLE
Update caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8164,9 +8164,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001254",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001254.tgz",
-      "integrity": "sha512-GxeHOvR0LFMYPmFGA+NiTOt9uwYDxB3h154tW2yBYwfz2EMX3i1IBgr6gmJGfU0K8KQsqPa5XqLD8zVdP5lUzA=="
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
     },
     "canonicalize": {
       "version": "1.0.5",


### PR DESCRIPTION
The result of running [`npx browserslist@latest --update-db`](https://github.com/browserslist/browserslist#browsers-data-updating). It seems like a good idea to update this per the link.