### PR TITLE
Replace custom method with Array#includes

### DIFF
--- a/src/models/soukai/MediaContainer.ts
+++ b/src/models/soukai/MediaContainer.ts
@@ -104,11 +104,11 @@ export default class MediaContainer extends SolidContainerModel {
         ];
 
         return properties.length !== expectedProperties.length
-            || expectedProperties.some(property => !Arr.contains(property, properties))
-            || Arr.create(containerResource['@type']).some((type: string) => !Arr.contains(type, [
+            || expectedProperties.some(property => !properties.includes(property))
+            || Arr.create(containerResource['@type']).some((type: string) => ![
                 'https://www.w3.org/ns/ldp#Resource',
                 'https://www.w3.org/ns/ldp#Container',
-            ]));
+            ].includes(type));
     }
 
     private fixLegacyAttributes(name: string, updatedAt: Date): void {

--- a/src/models/soukai/Movie.ts
+++ b/src/models/soukai/Movie.ts
@@ -2,7 +2,6 @@ import { SolidModel, SolidHasManyRelation } from 'soukai-solid';
 import { urlRoute } from '@noeldemartin/utils';
 import Soukai, { FieldType, MultiModelRelation } from 'soukai';
 
-import Arr from '@/utils/Arr';
 import Str from '@/utils/Str';
 import TMDBMoviesParser from '@/utils/parsers/TMDBMoviesParser';
 import TMDBResolver from '@/utils/media/TMDBResolver';
@@ -113,7 +112,7 @@ export default class Movie extends SolidModel {
 
     public is(movie: Movie): boolean {
         return this.slug === movie.slug
-            || !!this.externalUrls.find(url => Arr.contains(url, movie.externalUrls));
+            || !!this.externalUrls.find(url => movie.externalUrls.includes(url));
     }
 
     // TODO remove when this is fixed in soukai-solid.

--- a/src/services/Search.ts
+++ b/src/services/Search.ts
@@ -6,7 +6,6 @@ import Services from '@/services';
 
 import TheMovieDBApi from '@/api/TheMovieDBApi';
 
-import Arr from '@/utils/Arr';
 import DOM from '@/utils/DOM';
 import Str from '@/utils/Str';
 import Time, { DebouncedFunction } from '@/utils/Time';
@@ -251,7 +250,7 @@ export default class Search extends Service<State> {
     private captureHotKey({ target, key }: KeyboardEvent): boolean {
         if (
             !this.open &&
-            Arr.contains(key.toLowerCase(), ['s', '/']) &&
+            ['s', '/'].includes(key.toLowerCase()) &&
             !DOM.isWritable(target)
         ) {
             this.start();

--- a/src/utils/Arr.ts
+++ b/src/utils/Arr.ts
@@ -4,10 +4,6 @@ class Arr {
         return Array.isArray(item) ? item : [item];
     }
 
-    public contains<T>(needle: T, haystack: T[]): boolean {
-        return haystack.indexOf(needle) !== -1;
-    }
-
     public flatten<T>(items: T[][]): T[] {
         return items.reduce((flattenedItems, nestedItems) => [...flattenedItems, ...nestedItems], []);
     }

--- a/src/utils/DOM.ts
+++ b/src/utils/DOM.ts
@@ -1,5 +1,3 @@
-import Arr from './Arr';
-
 const NON_WRITABLE_INPUT_TYPES = ['submit', 'reset', 'checkbox', 'radio'];
 
 class DOM {
@@ -13,10 +11,7 @@ class DOM {
         return name === 'select'
             || (
                 name === 'input' &&
-                !Arr.contains(
-                    (element.getAttribute('type') || 'text').toLowerCase(),
-                    NON_WRITABLE_INPUT_TYPES,
-                )
+                !NON_WRITABLE_INPUT_TYPES.includes((element.getAttribute('type') || 'text').toLowerCase())
             )
             || name === 'textarea'
             || element.isContentEditable;

--- a/src/utils/Errors.ts
+++ b/src/utils/Errors.ts
@@ -2,7 +2,6 @@ import { DocumentFormat, MalformedDocumentError } from 'soukai-solid';
 import { init, captureException } from '@sentry/browser';
 import { UnauthorizedError } from '@noeldemartin/solid-utils';
 
-import Arr from '@/utils/Arr';
 import Storage from '@/utils/Storage';
 
 const STORAGE_ENABLED_KEY = 'media-kraken-error-reporting';
@@ -160,7 +159,7 @@ class Errors {
 
         const url = new URL(location.href);
 
-        return Arr.contains(url.searchParams.get('error_reporting'), ['1', 'true', 'on', 'yes']);
+        return ['1', 'true', 'on', 'yes'].includes(url.searchParams.get('error_reporting')!!);
     }
 
     private initializeSentry(): void {

--- a/src/utils/parsers/TVisoMoviesParser.ts
+++ b/src/utils/parsers/TVisoMoviesParser.ts
@@ -1,7 +1,6 @@
 import MediaValidationError from '@/errors/MediaValidationError';
 import UnsuitableMediaError from '@/errors/UnsuitableMediaError';
 
-import Arr from '@/utils/Arr';
 import Time from '@/utils/Time';
 
 import Movie from '@/models/soukai/Movie';
@@ -37,7 +36,7 @@ class TVisoMoviesParser implements MediaParser<Data, Movie> {
         if (
             typeof data.title !== 'string' ||
             (data.imdb !== null && typeof data.imdb !== 'string') ||
-            !Arr.contains(data.status, Object.values(Status)) ||
+            !Object.values(Status).includes(data.status) ||
             !Time.isValidDateString(data.checkedDate)
         )
             throw new MediaValidationError(['Invalid format']);

--- a/src/workers/LoadMediaWorker.ts
+++ b/src/workers/LoadMediaWorker.ts
@@ -13,7 +13,6 @@ import User from '@/models/users/User';
 
 import SolidAuth from '@/authentication/SolidAuth';
 
-import Arr from '@/utils/Arr';
 import JSONUserParser from '@/utils/parsers/JSONUserParser';
 
 import WebWorker from './WebWorker';
@@ -117,7 +116,7 @@ export default class LoadMediaWorker extends WebWorker<Parameters, Result> {
 
     private async loadMoviesFromCache(): Promise<void> {
         const operations = this.moviesContainer.documents.map(async document => {
-            if (Arr.contains(document.url, this.config.ignoredDocumentUrls))
+            if (this.config.ignoredDocumentUrls.includes(document.url))
                 return;
 
             const models = await ModelsCache.getFromDocument(document);
@@ -134,8 +133,8 @@ export default class LoadMediaWorker extends WebWorker<Parameters, Result> {
 
     private async loadMoviesFromDatabase(): Promise<void> {
         const documents = this.moviesContainer.documents.filter(document =>
-            !Arr.contains(document.url, this.config.ignoredDocumentUrls) &&
-            !Arr.contains(document.url, this.processedDocumentsUrls),
+            !this.config.ignoredDocumentUrls.includes(document.url) &&
+            !this.processedDocumentsUrls.includes(document.url),
         );
 
         if (documents.length === 0)


### PR DESCRIPTION
`Array#includes` is already used around the codebase, so we might as well use it everywhere instead of having a custom implementation of it.